### PR TITLE
web3移行バグ

### DIFF
--- a/frontend/src/pages/[type]/[daoId]/[projectId]/settings/migration.tsx
+++ b/frontend/src/pages/[type]/[daoId]/[projectId]/settings/migration.tsx
@@ -93,6 +93,8 @@ const Page = ({ isWeb3 }: props) => {
           voterReward || 0,
           durationDay || 7
         )
+      } else {
+        throw new Error("Blockchain processing failed. Please try again.")
       }
 
       setLoading(false)

--- a/frontend/src/pages/[type]/[daoId]/[projectId]/settings/migration.tsx
+++ b/frontend/src/pages/[type]/[daoId]/[projectId]/settings/migration.tsx
@@ -12,7 +12,7 @@ import { Button, Card, Center, Container, Loader, Stack, Table, Text, TextInput,
 import { ethers } from "ethers"
 import { useAtom } from "jotai"
 import { useRouter } from "next/router"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 type props = {
   isWeb3: boolean
@@ -37,6 +37,10 @@ const Page = ({ isWeb3 }: props) => {
   const [loading, setLoading] = useState(false)
   const [deployErrorMessage, setDeployErrorMessage] = useState("")
   const [isSetToken, setIsSetToken] = useState(false)
+
+  useEffect(() => {
+    if (!daoInfo) load()
+  }, [])
 
   const durationDay = pollDetail
     ? Math.floor((pollDetail.endTimeStamp.getTime() - pollDetail.startTimeStamp.getTime()) / (60 * 60 * 24 * 1000))
@@ -76,20 +80,21 @@ const Page = ({ isWeb3 }: props) => {
     try {
       await migrateDao()
 
-      if (!daoInfo) await load()
+      if (daoInfo) {
+        await createDao(
+          daoId as string,
+          projectId as string,
+          daoInfo.name,
+          daoInfo.description,
+          "https://...",
+          daoInfo.logo,
+          tokenAddress,
+          contributorReward || 0,
+          voterReward || 0,
+          durationDay || 7
+        )
+      }
 
-      await createDao(
-        daoId as string,
-        projectId as string,
-        daoInfo?.name || "",
-        daoInfo?.description || "",
-        "https://...",
-        daoInfo?.logo || "",
-        tokenAddress,
-        contributorReward || 0,
-        voterReward || 0,
-        durationDay || 7
-      )
       setLoading(false)
     } catch (err: any) {
       //必要に応じてRetry


### PR DESCRIPTION
migrationページ、表示時にdaoInfoがundefinedだったら、ロードするようにした

エラーの原因は、createDaoに渡されている引数がundefinedになる可能性があるからだと思う。
/migrationページでリロードするとDaoInfoAtom情報が消えるため、エラー発生
**直前で、loadしてもやはりsetDaoInfoはすぐに反映されていなかった**
